### PR TITLE
fix path error on windows

### DIFF
--- a/fpga/project.py
+++ b/fpga/project.py
@@ -200,7 +200,7 @@ class Project:
                 else:
                     filetype = 'constraint'
                 _log.debug('add_files: %s filetype detected', filetype)
-            file = os.path.relpath(file, self.outdir)
+            file = os.path.relpath(file, self.outdir).replace(os.path.sep, "/")
             self.tool.add_file(file, filetype, library, options)
 
     def get_files(self):


### PR DESCRIPTION
## Problem
In windows environment, pyfpga make incorrect path for tcl file.
``` vivado.tcl
fpga_file ..\..\hdl\blinking.vhdl
```
Tcl file does not use "\\" as path split character.

## Why happen
Unix's / Linux's default path split character is "/", bud windows is "\\".

## What I did
I add a replace command on path. This replace "\\" with "/".
So new output is
``` vivado.tcl
fpga_file ../../hdl/blinking.vhdl
```

## Test environment
- WIndows 10 20h2
- Vivado 2016.4
- python 3.9.1

Tested on examples/vivado/vivado.py