### PR TITLE
Fix 'Hierarchy out of date' issue 

### DIFF
--- a/pyfpga/templates/vivado.jinja
+++ b/pyfpga/templates/vivado.jinja
@@ -47,6 +47,9 @@ set_property GENERIC { {{ params.items() | map('join', '=') | join(' ') }} } -ob
 
 {% if hooks %}{{ hooks.postcfg | join('\n') }}{% endif %}
 
+set_property source_mgmt_mode All [current_project]
+update_compile_order -fileset sources_1
+
 close_project
 
 {% endif %}


### PR DESCRIPTION
Fix 'Hierarchy out of date' issue found in the vivado gui when a project is created, #63 