### PR TITLE
Fix new_project location directory to match the open_project path in 'syn' step

### DIFF
--- a/pyfpga/templates/libero.jinja
+++ b/pyfpga/templates/libero.jinja
@@ -9,7 +9,7 @@
 {% if 'cfg' in steps %}# Project configuration -------------------------------------------------------
 
 if { [ file exists {{ project }} ] } { file delete -force -- {{ project }} }
-new_project -name {{ project }} -location libero -hdl VERILOG -family {{ family }}
+new_project -name {{ project }} -location {{ project }} -hdl VERILOG -family {{ family }}
 set_device -family {{ family }} -die {{ device }} -package {{ package}} -speed {{ speed }} -part_range {{ prange }}
 
 {% if hooks %}{{ hooks.precfg | join('\n') }}{% endif %}


### PR DESCRIPTION

The subsequent open_project call used
<project>/<project>.prjx which never exists, causing the build to fail at the synthesis step.